### PR TITLE
This makes the drag/drop in the timeline way less flaky

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -27,7 +27,11 @@
         }).toArray();
     };
     
-    setupDrag();
+    nativesortable(fileList[0], ".col", {
+        change: function() {
+            App.rebuildTimeline();
+        }
+    });
     
 
     // drag and drop setup.
@@ -40,13 +44,13 @@
                 }
             },
             error: function(file) {
-                fileList.append("<div class='col error'>Error<div class='fil3l'></div></div>");
+                fileList.append("<div draggable=true class='col error'>Error<div class='fil3l'></div></div>");
             },
             skip: function(file) {
-                fileList.append("<div class='col skip'>Skip<div class='fil3l'></div></div>");
+                fileList.append("<div draggable=true class='col skip'>Skip<div class='fil3l'></div></div>");
             },
             load: function(e, file) {
-                fileList.append("<div class='col'><img class='rotateimg' data-rotation='0' src='"+e.target.result+"' /><div class='fil3l'></div></div>");
+                fileList.append("<div draggable=true class='col'><img class='rotateimg' data-rotation='0' src='"+e.target.result+"' /><div class='fil3l'></div></div>");
 
                 var originalimg = new Image();
 


### PR DESCRIPTION
Also fixes https://github.com/h5bp/mothereffinganimatedgif/issues/24.  

Wow, I didn't realize how hard it would be to make a little utility to handle this.  I decided to break it out into a mini project here: https://github.com/bgrins/nativesortable/blob/master/nativesortable.js.  The really tricky part is that images are: 
- draggable by default
- still cause the `dragleave` event to fire on the draggable container even _if_ you manually turn off draggable.

I don't really know what to say about this whole API...  I think what i have is a good starting point for handling this type of interaction.  I couldn't really find any good, small, native plugins for handling sortable lists.
