### PR TITLE
Update no support message to mention D&D

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
         
         <div id="dropArea">
         	<h2 class='support'><span>Drag and <em>Drop</em> images here</span></h2>
-        	<h2 class='nosupport'>Your browser doesn't support File Reading :(</h2>
+        	<h2 class='nosupport'>Your browser doesn't support FileReader, Drag and Drop, or some other modern required features. :(</h2>
         </div>
         
         <div id='results'>


### PR DESCRIPTION
Which can be seen for a second before the html5please API kicks in. For example, Opera 11.62 supports FileReader, but not Drag and Drop. So this message is a bit off.
