### PR TITLE
Replace H5P-API-call with new source

### DIFF
--- a/assets/js/startup.js
+++ b/assets/js/startup.js
@@ -23,7 +23,7 @@ var support = FileReaderJS.enabled && Modernizr.draganddrop &&
 if (!support) {
     $("body").addClass("disabled");
     var caniscript = document.createElement('script');
-    caniscript.src = 'http://sandbox.thewikies.com/caniuse/json+filereader+draganddrop+querySelector+postmessage.html?callback=canicallback';
+    caniscript.src = 'http://api.html5please.com/json+filereader+draganddrop+querySelector+postmessage.json?callback=canicallback&texticon&html&readable';
     document.body.appendChild(caniscript);
 } else {
 


### PR DESCRIPTION
This fixes issues where a message was shown without correct content (in non-supporting browsers like Safari or old FF; no icons, no features).
This was reported in [issue #60](https://github.com/h5bp/html5please-api/issues/60) at the H5P-API repo.
