### PR TITLE
Fixing the ShowDownload button JS exception in Chrome -  startup.js

### DIFF
--- a/assets/js/startup.js
+++ b/assets/js/startup.js
@@ -8,7 +8,7 @@ Modernizr
     .addTest("download",    "download" in document.createElement("a"))
     .addTest("formdata",    !!(window.FormData && "append" in window.FormData.prototype));
 
-if(!Modernizr.download && $('#saveasbro').length == 0) {
+if( ( !Modernizr.bloburls || !Modernizr.blobbuilder || !Modernizr.download ) && $('#saveasbro').length == 0) {
     var iframe = document.createElement("iframe");
     iframe.src = "http://saveasbro.com/gif/";
     iframe.setAttribute('style', 'position: absolute; visibility: hidden; left: -999em;');


### PR DESCRIPTION
Showing the download link in showDownload button view checks the following 
Modernizr tests to pass

Modernizr.download && Modernizr.bloburls && Modernizr.blobbuilder

In the Else condition , it expects the download iFrame should be present , else
throwing uncaught JS exception.

So the same check should be here also for creating the iFrame.
