### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-#MOTHEREFFINGANIMATEDGIF
-##Drag + Drop, Client-side, Animated GIF Creator
+# MOTHEREFFINGANIMATEDGIF
+## Drag + Drop, Client-side, Animated GIF Creator
 
 This is an [H5BP](http://h5bp.github.com) community project. [H5BP](http://h5bp.github.com) is where you'll find a bunch of people creating open source software. 
 [Fork](http://h5bp.github.com) a project and get involved!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
